### PR TITLE
Ethereum and Arbitrum RPC charts

### DIFF
--- a/charts/arbitrum-rpc/.helmignore
+++ b/charts/arbitrum-rpc/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/arbitrum-rpc/Chart.yaml
+++ b/charts/arbitrum-rpc/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: arbitrum-rpc
+description: Deploy an Arbitrum RPC server using Nitro
+type: application
+version: 0.1.0
+appVersion: "2.1.1-e9d8842"
+keywords:
+  - cryptocurrency
+  - Arbitrum
+  - Nitro
+  - geth
+  - RPCs
+home: https://arbitrum.io/
+maintainers:
+  - name: Route 1337 LLC
+    url: https://www.route1337.com
+deprecated: false

--- a/charts/arbitrum-rpc/templates/nitro.yaml
+++ b/charts/arbitrum-rpc/templates/nitro.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Values.rpcService.name }}
+  namespace: {{ .Values.namespace}}
+spec:
+  serviceName: {{ .Values.rpcService.name }}
+  replicas: {{ .Values.rpcService.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Values.rpcService.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.rpcService.name }}
+    spec:
+      initContainers:
+        - name: volume-permissions-fix
+          image: busybox
+          command: ['/bin/sh', '-c']
+          args:
+            - |
+              #!/bin/sh
+              mkdir -p /home/user/.arbitrum/tmp &&
+              chmod -Rf 777 /home/user/.arbitrum
+          volumeMounts:
+            - name: arbitrum-data
+              mountPath: /home/user/.arbitrum
+      containers:
+        - name: {{ .Values.rpcService.name }}
+          image: "{{ .Values.rpcService.image.repository }}:v{{ .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.rpcService.image.pullPolicy }}
+          args:
+            - "--init.url={{ .Values.rpcService.init.url }}"
+            - "--init.download-path={{ .Values.rpcService.init.downloadPath }}"
+            - "--parent-chain.connection.url={{ .Values.rpcService.gethRpcUrl }}"
+            - "--chain.id={{ .Values.rpcService.chainId }}"
+            - "--http.api=net,web3,eth,debug"
+            - "--http.corsdomain=*"
+            - "--http.addr=0.0.0.0"
+            - "--http.vhosts=*"
+            - "--ws.port=8548"
+            - "--ws.addr=0.0.0.0"
+            - "--ws.origins=*"
+          ports:
+            - containerPort: 8547
+              name: rpc
+            - containerPort: 9642
+              name: sequencer
+            - containerPort: 8548
+              name: ws-rpc
+          volumeMounts:
+            - name: arbitrum-data
+              mountPath: /home/user/.arbitrum
+          resources:
+            limits:
+              memory: {{ .Values.rpcService.resources.limits.memory | quote }}
+            requests:
+              memory: {{ .Values.rpcService.resources.requests.memory | quote }}
+  volumeClaimTemplates:
+    - metadata:
+        name: arbitrum-data
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        storageClassName: {{ .Values.rpcService.volume.storageClass }}
+        resources:
+          requests:
+            storage: {{ .Values.rpcService.volume.capacity }}

--- a/charts/arbitrum-rpc/templates/services.yaml
+++ b/charts/arbitrum-rpc/templates/services.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.rpcService.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ .Values.rpcService.name }}
+  ports:
+    - name: rpc
+      port: 8547
+      targetPort: 8547
+    - name: sequencer
+      port: 9642
+      targetPort: 9642
+    - name: ws-rpc
+      port: 8548
+      targetPort: 8548

--- a/charts/arbitrum-rpc/values.yaml
+++ b/charts/arbitrum-rpc/values.yaml
@@ -1,0 +1,21 @@
+namespace: rpcs
+
+rpcService:
+  name: arbitrum-nitro
+  image:
+    repository: offchainlabs/nitro-node
+    pullPolicy: IfNotPresent
+  replicas: 1
+  resources:
+    limits:
+      memory: "24000Mi"
+    requests:
+      memory: "16000Mi"
+  volume:
+    capacity: 3000Gi
+    storageClass: rpc-sc
+  gethRpcUrl: http://geth-mainnet-full.rpcs.svc.cluster.local:8545
+  chainId: 42161
+  init:
+    url: https://snapshot.arbitrum.io/mainnet/nitro.tar
+    downloadPath: /home/user/.arbitrum/tmp

--- a/charts/ethereum-rpc/.helmignore
+++ b/charts/ethereum-rpc/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/ethereum-rpc/Chart.yaml
+++ b/charts/ethereum-rpc/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: ethereum-rpc
+description: Deploy an Ethereum Mainnet RPC server using geth and Lighthouse
+type: application
+version: 0.1.0
+appVersion: "1.13.3"
+keywords:
+  - cryptocurrency
+  - Ethereum
+  - Mainnet
+  - geth
+  - Lighthouse
+  - RPCs
+home: https://ethereum.org/en/
+maintainers:
+  - name: Route 1337 LLC
+    url: https://www.route1337.com
+deprecated: false

--- a/charts/ethereum-rpc/templates/diagnostic.yaml
+++ b/charts/ethereum-rpc/templates/diagnostic.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.diagnostic }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: "{{ .Values.rpcService.name }}-diag"
+  namespace: {{ .Values.namespace }}
+spec:
+  serviceName: "{{ .Values.rpcService.name }}-diag"
+  replicas: {{ .Values.rpcService.replicas }}
+  selector:
+    matchLabels:
+      app: "{{ .Values.rpcService.name }}-diag"
+  template:
+    metadata:
+      labels:
+        app: "{{ .Values.rpcService.name }}-diag"
+    spec:
+      containers:
+        - name: "{{ .Values.rpcService.name }}-diag"
+          image: ghcr.io/ahrenstein/docker-debugging:latest
+          imagePullPolicy: {{ .Values.rpcService.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          volumeMounts:
+            - name:  {{ .Values.sharedEfsVolume.name }}
+              mountPath: /efs
+      volumes:
+        - name: {{ .Values.sharedEfsVolume.name }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.sharedEfsVolume.name }}
+{{- end }}

--- a/charts/ethereum-rpc/templates/geth.yaml
+++ b/charts/ethereum-rpc/templates/geth.yaml
@@ -1,0 +1,96 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Values.rpcService.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  serviceName: {{ .Values.rpcService.name }}
+  replicas: {{ .Values.rpcService.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Values.rpcService.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.rpcService.name }}
+    spec:
+      containers:
+        - name: {{ .Values.rpcService.name }}
+          image: "{{ .Values.rpcService.image.repository }}"
+          imagePullPolicy: {{ .Values.rpcService.image.pullPolicy }}
+          command:
+            - sh
+            - -ac
+            - >
+              exec geth
+{{- if .Values.rpcService.goerli }}
+              --goerli
+{{- end }}
+              --syncmode=snap
+              --http
+              --http.api=txpool,eth,net,web3,personal
+              --http.addr=0.0.0.0
+              --http.port=8545
+              --http.corsdomain=*
+              --http.vhosts=*
+              --ws
+              --ws.api=txpool,eth,net,web3,personal
+              --ws.addr=0.0.0.0
+              --ws.port=8546
+              --ws.origins=*
+              --authrpc.addr=0.0.0.0
+              --authrpc.port=8551
+              --authrpc.vhosts=*
+              --authrpc.jwtsecret /root/.ethereum/geth/jwtsecret
+              --datadir=/data
+              --db.engine=pebble
+          ports:
+            - name: http-rpc
+              containerPort: 8545
+              protocol: TCP
+            - name: ws-rpc
+              containerPort: 8546
+              protocol: TCP
+            - name: auth-rpc
+              containerPort: 8551
+              protocol: TCP
+            - name: p2p-tcp
+              containerPort: 30303
+              protocol: TCP
+            - name: p2p-udp
+              containerPort: 30303
+              protocol: UDP
+{{/*          livenessProbe:*/}}
+{{/*            tcpSocket:*/}}
+{{/*              port: http-rpc*/}}
+{{/*            initialDelaySeconds: 60*/}}
+{{/*            periodSeconds: 120*/}}
+{{/*          readinessProbe:*/}}
+{{/*            tcpSocket:*/}}
+{{/*              port: http-rpc*/}}
+{{/*            initialDelaySeconds: 10*/}}
+{{/*            periodSeconds: 10*/}}
+          volumeMounts:
+            - name: rpc-data
+              mountPath: "/data"
+            - name:  {{ .Values.sharedEfsVolume.name }}
+              mountPath: /root
+          resources:
+            limits:
+              memory: {{ .Values.rpcService.resources.limits.memory | quote }}
+            requests:
+              memory: {{ .Values.rpcService.resources.requests.memory | quote }}
+      volumes:
+        - name: {{ .Values.sharedEfsVolume.name }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.sharedEfsVolume.name }}
+  volumeClaimTemplates:
+    - metadata:
+        name: rpc-data
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        storageClassName: {{ .Values.rpcService.volume.storageClass }}
+        resources:
+          requests:
+            storage: {{ .Values.rpcService.volume.capacity }}

--- a/charts/ethereum-rpc/templates/lighthouse.yaml
+++ b/charts/ethereum-rpc/templates/lighthouse.yaml
@@ -1,0 +1,100 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Values.consensusClient.name }}
+  namespace: {{ .Values.namespace}}
+spec:
+  serviceName: {{ .Values.consensusClient.name }}
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Values.consensusClient.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.consensusClient.name }}
+    spec:
+{{- if .Values.consensusClient.keepWithRpcService }}
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - {{ .Values.rpcService.name }}
+              topologyKey: "kubernetes.io/hostname"
+{{- end}}
+      containers:
+        - name: {{ .Values.consensusClient.name }}
+          image: {{ .Values.consensusClient.image.repository }}
+          imagePullPolicy: {{ .Values.consensusClient.image.pullPolicy }}
+          command:
+            - sh
+            - -ac
+            - >
+              exec lighthouse
+              beacon_node
+{{- if .Values.rpcService.goerli }}
+              --network goerli
+{{- end }}
+              --disable-upnp
+              --disable-enr-auto-update
+              --listen-address=0.0.0.0
+              --port=9000
+              --discovery-port=9000
+              --http
+              --http-address=0.0.0.0
+              --http-port=5052
+              --execution-endpoint=http://{{ .Values.rpcService.name }}.{{ .Values.namespace }}.svc.cluster.local:8551
+              --execution-jwt="/geth/.ethereum/geth/jwtsecret"
+{{- if .Values.rpcService.goerli }}
+              --checkpoint-sync-url=https://goerli.beaconstate.info/
+{{- else }}
+              --checkpoint-sync-url=https://beaconstate.info/
+{{- end }}
+          ports:
+            - containerPort: 9000
+              name: p2p-tcp
+              protocol: TCP
+            - containerPort: 9000
+              name: p2p-udp
+              protocol: UDP
+            - containerPort: 5052
+              name: http-api
+          volumeMounts:
+            - name: beacon-data
+              mountPath: /root
+            - name:  {{ .Values.sharedEfsVolume.name }}
+              mountPath: /geth/
+              readOnly: true
+{{/*          livenessProbe:*/}}
+{{/*            tcpSocket:*/}}
+{{/*              port: http-api*/}}
+{{/*            initialDelaySeconds: 60*/}}
+{{/*            periodSeconds: 120*/}}
+{{/*          readinessProbe:*/}}
+{{/*            tcpSocket:*/}}
+{{/*              port: http-api*/}}
+{{/*            initialDelaySeconds: 10*/}}
+{{/*            periodSeconds: 10*/}}
+          resources:
+            limits:
+              memory: {{ .Values.consensusClient.resources.limits.memory | quote }}
+            requests:
+              memory: {{ .Values.consensusClient.resources.requests.memory | quote }}
+      volumes:
+        - name: {{ .Values.sharedEfsVolume.name }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.sharedEfsVolume.name }}
+  volumeClaimTemplates:
+    - metadata:
+        name: beacon-data
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        storageClassName: {{ .Values.consensusClient.volume.storageClass }}
+        resources:
+          requests:
+            storage: {{ .Values.consensusClient.volume.capacity }}

--- a/charts/ethereum-rpc/templates/services.yaml
+++ b/charts/ethereum-rpc/templates/services.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.consensusClient.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ .Values.consensusClient.name }}
+  ports:
+    - name: p2p-tcp
+      port: 9000
+      targetPort: 9000
+      protocol: TCP
+    - name: p2p-udp
+      port: 9000
+      targetPort: 9000
+      protocol: UDP
+    - name: api
+      port: 5052
+      targetPort: 5052
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.rpcService.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ .Values.rpcService.name }}
+  ports:
+    - name: auth-rpc
+      port: 8551
+      targetPort: 8551
+    - name: http-rpc
+      port: 8545
+      targetPort: 8545
+    - name: ws-rpc
+      port: 8546
+      targetPort: 8546
+    - name: p2p-tcp
+      port: 30303
+      targetPort: 30303
+      protocol: TCP
+    - name: p2p-udp
+      port: 30303
+      targetPort: 30303
+      protocol: UDP

--- a/charts/ethereum-rpc/templates/shared-volume.yaml
+++ b/charts/ethereum-rpc/templates/shared-volume.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ .Values.sharedEfsVolume.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  capacity:
+    storage: {{ .Values.sharedEfsVolume.capacity }}
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: {{ .Values.sharedEfsVolume.storageClass }}
+  csi:
+    driver: efs.csi.aws.com
+    volumeHandle: {{ .Values.sharedEfsVolume.filesystemId }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.sharedEfsVolume.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: {{ .Values.sharedEfsVolume.storageClass }}
+  resources:
+    requests:
+      storage: {{ .Values.sharedEfsVolume.capacity }}

--- a/charts/ethereum-rpc/values.yaml
+++ b/charts/ethereum-rpc/values.yaml
@@ -1,0 +1,41 @@
+namespace: rpcs
+
+diagnostic: false
+
+consensusClient:
+  name: lighthouse-beacon
+  image:
+    repository: sigp/lighthouse:latest
+    pullPolicy: Always
+  replicas: 1
+  resources:
+    limits:
+      memory: "24000Mi"
+    requests:
+      memory: "16000Mi"
+  volume:
+    capacity: 200Gi
+    storageClass: rpc-sc
+  keepWithRpcService: false
+
+rpcService:
+  name: geth-mainnet-full
+  goerli: false
+  image:
+    repository: ethereum/client-go:stable
+    pullPolicy: Always
+  replicas: 1
+  resources:
+    limits:
+      memory: "24000Mi"
+    requests:
+      memory: "16000Mi"
+  volume:
+    capacity: 2000Gi
+    storageClass: rpc-sc
+
+sharedEfsVolume: #TODO genericize to not just be EFS
+  name: "mainnet-jwtsecret"
+  filesystemId: ""
+  capacity: 1Gi
+  storageClass: "efs-sc"


### PR DESCRIPTION
Purpose
-------
Two new charts for running local RPC nodes.

1. Ethereum: geth+Lighthouse
2. Arbitrum Nitro

To Do
-----

1. Secrets converted to the modern SecretStore style of external secrets
2. Less AWS specific around volumes and other resources
